### PR TITLE
Update version in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:ecto_dbg, "~> 0.1.0", only: [:dev, :test]}
+    {:ecto_dbg, "~> 0.2.0", only: [:dev, :test]}
   ]
 end
 ```


### PR DESCRIPTION
With the current readme instructions the user would end up with an outdated version of ecto_dbg